### PR TITLE
Feature: Vets & API documentation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^4.19.1",
         "joi": "^17.12.2",
         "jsonwebtoken": "^9.0.2",
-        "nodemailer": "^6.9.13"
+        "nodemailer": "^6.9.13",
+        "swagger-ui-express": "^5.0.0"
       },
       "devDependencies": {
         "@prisma/client": "^5.11.0",
@@ -23,8 +24,10 @@
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^20.11.30",
+        "@types/swagger-ui-express": "^4.1.6",
         "nodemon": "^3.1.0",
         "prisma": "^5.11.0",
+        "swagger-autogen": "^2.23.7",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.3"
       }
@@ -325,6 +328,16 @@
         "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-UVSiGYXa5IzdJJG3hrc86e8KdZWLYxyEsVoUI4iPXc7CO4VZ3AfNP8d/8+hrDRIqz+HAaSMtZSqAsF3Nq2X/Dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/abbrev": {
@@ -659,6 +672,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -773,9 +795,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.1.tgz",
-      "integrity": "sha512-K4w1/Bp7y8iSiVObmCrtq8Cs79XjJc/RU2YYkZQ7wpUu5ZyZ7MtPHkqoMz4pf+mgXfNvo2qft8D9OnrH2ABk9w==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1191,6 +1213,18 @@
         "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -1913,6 +1947,49 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.12.3.tgz",
+      "integrity": "sha512-UAFxQSzxVkY/yfmipeMLj4LwH6I/ZGcfezwSquPm2U9CqOiHp8L6fD7TcyPDYfCZuHFaPw5y4io+fny37Ov9NQ=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "dev": "nodemon -e ts --watch 'src/**/*.ts' --exec 'tsc && node --env-file .env dist/app.js'"
+    "dev": "nodemon -e ts --watch 'src/**/*.ts' --exec 'tsc && node --env-file .env dist/app.js'",
+    "swagger": "node ./src/docs/index.mjs"
   },
   "keywords": [],
   "author": "Heba",
@@ -15,7 +16,8 @@
     "express": "^4.19.1",
     "joi": "^17.12.2",
     "jsonwebtoken": "^9.0.2",
-    "nodemailer": "^6.9.13"
+    "nodemailer": "^6.9.13",
+    "swagger-ui-express": "^5.0.0"
   },
   "devDependencies": {
     "@prisma/client": "^5.11.0",
@@ -24,8 +26,10 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.11.30",
+    "@types/swagger-ui-express": "^4.1.6",
     "nodemon": "^3.1.0",
     "prisma": "^5.11.0",
+    "swagger-autogen": "^2.23.7",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,11 @@
 import express from "express";
 import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
 import { notFound } from "./middlewares/notFound";
 import { errorHandler } from "./middlewares/errorHandler";
 import { staffRouter } from "./features/Staff/routes/staff.routes";
+import { vetsRouter } from "./features/Vets/routes/vets.routes";
+import config from "./docs/swagger-output.json";
 
 const app = express();
 const PORT = process.env.PORT || 5002;
@@ -10,7 +13,9 @@ const PORT = process.env.PORT || 5002;
 app.use(cors());
 app.use(express.json());
 
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(config));
 app.use("/api/v1/staff", staffRouter);
+app.use("/api/v1/vets", vetsRouter);
 
 app.use(errorHandler);
 app.all("*", notFound)

--- a/src/docs/index.mjs
+++ b/src/docs/index.mjs
@@ -1,0 +1,17 @@
+import swaggerAutogen from "swagger-autogen";
+
+const doc = {
+  info: {
+    title: "My API",
+    description: "Description",
+  },
+  host: process.env.HOST,
+};
+
+const outputFile = "./swagger-output.json";
+const routes = ["./src/app.ts"];
+
+/* NOTE: If you are using the express Router, you must pass in the 'routes' only the 
+root file where the route starts, such as index.js, app.js, routes.js, etc ... */
+
+swaggerAutogen()(outputFile, routes, doc);

--- a/src/docs/swagger-output.json
+++ b/src/docs/swagger-output.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "VetCare",
-    "description": "A vet clinic management API",
+    "title": "My API",
+    "description": "Description",
     "version": "1.0.0"
   },
   "basePath": "/",
@@ -22,7 +22,7 @@
   "paths": {
     "/api/v1/staff/current": {
       "get": {
-        "tags": ["Staff"],
+        "tags": ["Staff"], 
         "description": "",
         "parameters": [
           {
@@ -160,7 +160,7 @@
         }
       }
     },
-    "/api/v1/staff/": {
+    "/api/v1/staff/delete": {
       "delete": {
         "tags": ["Staff"],
         "description": "",
@@ -199,7 +199,47 @@
             "description": "Bad Request"
           }
         }
-      },
+      }
+    },
+    "/api/v1/staff/verify": {
+      "put": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/update": {
       "patch": {
         "tags": ["Staff"],
         "description": "",
@@ -233,44 +273,6 @@
                   "example": "any"
                 },
                 "job_title": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          }
-        }
-      }
-    },
-    "/api/v1/staff/verify": {
-      "put": {
-        "tags": ["Staff"],
-        "description": "",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "type": "string"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "email": {
                   "example": "any"
                 }
               }
@@ -322,7 +324,7 @@
     },
     "/api/v1/vets/former": {
       "get": {
-        "tags": ["Vets"],
+         "tags": ["Vets"],
         "description": "",
         "parameters": [
           {
@@ -437,8 +439,46 @@
         }
       }
     },
-    "/api/v1/vets/": {
+    "/api/v1/vets/verify": {
       "put": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/v1/vets/update": {
+      "patch": {
         "tags": ["Vets"],
         "description": "",
         "parameters": [
@@ -485,7 +525,9 @@
             "description": "Bad Request"
           }
         }
-      },
+      }
+    },
+    "/api/v1/vets/delete": {
       "delete": {
         "tags": ["Vets"],
         "description": "",

--- a/src/docs/swagger-output.json
+++ b/src/docs/swagger-output.json
@@ -1,0 +1,530 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "VetCare",
+    "description": "A vet clinic management API",
+    "version": "1.0.0"
+  },
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "tags": [
+    {
+      "name": "Staff",
+      "description": "Endpoints related to staff"
+    },
+    {
+      "name": "Vets",
+      "description": "Endpoints related to veterinarians"
+    }
+  ],
+  "paths": {
+    "/api/v1/staff/current": {
+      "get": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/former": {
+      "get": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/register": {
+      "post": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "phone_number": {
+                  "example": "any"
+                },
+                "job_title": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/login": {
+      "post": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/": {
+      "delete": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "example": "any"
+                },
+                "exit_reason": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "phone_number": {
+                  "example": "any"
+                },
+                "job_title": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/verify": {
+      "put": {
+        "tags": ["Staff"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/v1/vets/current": {
+      "get": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/vets/former": {
+      "get": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/vets/register": {
+      "post": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "phone_number": {
+                  "example": "any"
+                },
+                "job_title": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/v1/vets/login": {
+      "post": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/vets/": {
+      "put": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "phone_number": {
+                  "example": "any"
+                },
+                "job_title": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Vets"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "example": "any"
+                },
+                "exit_reason": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/docs/swagger-output.json
+++ b/src/docs/swagger-output.json
@@ -240,7 +240,7 @@
       }
     },
     "/api/v1/staff/update": {
-      "patch": {
+      "put": {
         "tags": ["Staff"],
         "description": "",
         "parameters": [
@@ -478,7 +478,7 @@
       }
     },
     "/api/v1/vets/update": {
-      "patch": {
+      "put": {
         "tags": ["Vets"],
         "description": "",
         "parameters": [

--- a/src/features/Staff/controllers/get-all-former.staff.ts
+++ b/src/features/Staff/controllers/get-all-former.staff.ts
@@ -2,9 +2,16 @@ import { Request, Response, NextFunction } from "express";
 import { statusCode } from "../../../utils/httpStatusCode";
 import { prisma } from "../../../config/prisma";
 import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
 const { SUCCESS, FAIL } = statusCode;
 
 const getAllFormerStaff = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const token = req.decodedToken;
+    if(token?.permission_type !== "Admin") {
+        const err = new globalError("Unauthorized to perform this action.", 401
+        ,FAIL)
+        return next(err);
+    }
     const page = parseInt(req.query.page as string) || 1; // Default page 1
     const limit = parseInt(req.query.limit as string) || 15; // Default 15 results per page
     const offset = (page - 1) * limit;

--- a/src/features/Staff/controllers/login.staff.ts
+++ b/src/features/Staff/controllers/login.staff.ts
@@ -32,7 +32,7 @@ const staffLogin = wrapper(async (req: Request, res: Response, next: NextFunctio
     const token = await generateJwt({id: user.id, permission_type: user.permission_type});
     return res.status(200).send({
         status: SUCCESS,
-        message: "Account has been sucessfully created.",
+        message: "User sucessfully logged in.",
         data: {
             id: user.id,
             email: user.email,

--- a/src/features/Staff/controllers/registration.staff.ts
+++ b/src/features/Staff/controllers/registration.staff.ts
@@ -10,13 +10,13 @@ const staffRegistration = wrapper(async (req: Request, res: Response, next: Next
     const {name, email, password, phone_number, job_title } = req.body;
     const job = await prisma.jobs.findFirst({where: {title: job_title}});
     if (!job) {
-        const err = new globalError("Please provide a valid job title [Receptionist, HR, Manager, Veterinarian, Asistant or Technician].", 400
+        const err = new globalError("Please provide a valid job title [Receptionist, HR, or Manager].", 400
         ,FAIL)
         return next(err);
     }
     const emailFound = await prisma.staff.findUnique({where: {email}});
     if (emailFound) {
-        const err = new globalError("Email already exist.", 400
+        const err = new globalError("Email already exists.", 400
         ,FAIL)
         return next(err);
     }

--- a/src/features/Staff/controllers/update.staff.ts
+++ b/src/features/Staff/controllers/update.staff.ts
@@ -8,7 +8,7 @@ const { SUCCESS, FAIL } = statusCode;
 const staffUpdate = wrapper(async (req: Request, res: Response, next: NextFunction) => {
     const {id, email, password, phone_number, job_title } = req.body;
     if(!email && !password && !phone_number && !job_title) {
-        const err = new globalError("An email, a password or a phone number is required to update.", 404
+        const err = new globalError("An email, a password or a phone number is required to update an account.", 404
         ,FAIL)
         return next(err);
     }
@@ -45,7 +45,7 @@ const staffUpdate = wrapper(async (req: Request, res: Response, next: NextFuncti
     if(token?.permission_type === "Admin" && job_title) {
         const job = await prisma.jobs.findFirst({where: {title: job_title}});
         if (!job) {
-        const err = new globalError("Please provide a valid job title [Receptionist, HR, Manager, Veterinarian, Asistant or Technician].", 400
+        const err = new globalError("Please provide a valid job title [Receptionist, HR, or Manager].", 400
         ,FAIL)
         return next(err);
         } else {

--- a/src/features/Staff/routes/staff.routes.ts
+++ b/src/features/Staff/routes/staff.routes.ts
@@ -32,6 +32,6 @@ staffRouter.route("/delete").delete(verifyToken, staffDeleteValidation, staffDel
 
 staffRouter.route("/verify").put(verifyToken, staffVerifyValidation, staffVerify);
 
-staffRouter.route("/update").patch(verifyToken, staffUpdateValidation, staffUpdate);
+staffRouter.route("/update").put(verifyToken, staffUpdateValidation, staffUpdate);
 
 export { staffRouter}

--- a/src/features/Staff/routes/staff.routes.ts
+++ b/src/features/Staff/routes/staff.routes.ts
@@ -28,10 +28,10 @@ staffRouter.route("/register").post(staffRegistrationValidation, staffRegistrati
 
 staffRouter.route("/login").post(staffLoginValidation, staffLogin);
 
-staffRouter.route("/").delete(verifyToken, staffDeleteValidation, staffDelete);
+staffRouter.route("/delete").delete(verifyToken, staffDeleteValidation, staffDelete);
 
 staffRouter.route("/verify").put(verifyToken, staffVerifyValidation, staffVerify);
 
-staffRouter.route("/").patch(verifyToken, staffUpdateValidation, staffUpdate);
+staffRouter.route("/update").patch(verifyToken, staffUpdateValidation, staffUpdate);
 
 export { staffRouter}

--- a/src/features/Vets/controllers/delete.vets.ts
+++ b/src/features/Vets/controllers/delete.vets.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
+const { SUCCESS, FAIL } = statusCode;
+
+const vetsDelete = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const {id, exit_reason } = req.body;
+    const token = req.decodedToken;
+    if(token?.permission_type !== "Admin") {
+        const err = new globalError("Unauthorized to perform this action.", 401
+        ,FAIL)
+        return next(err);
+    }
+    const user = await prisma.veterinarians.findUnique({where: {id}});
+    if (!user) {
+        const err = new globalError("Invalid id.", 400
+        ,FAIL)
+        return next(err);
+    }
+    await prisma.formerVets.create({
+        data: {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            phone_number: user.phone_number,
+            job_title: user.job_title,
+            exit_date: new Date(),
+            exit_reason: exit_reason
+        }
+    });
+    await prisma.veterinarians.delete({where: {id: user.id}});
+    return res.status(204).send({
+        status: SUCCESS,
+        message: "Account successfully deleted.",
+        data: null
+    });
+});
+
+export { vetsDelete }

--- a/src/features/Vets/controllers/get-all-former.vets.ts
+++ b/src/features/Vets/controllers/get-all-former.vets.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
+const { SUCCESS, FAIL } = statusCode;
+
+const getAllFormerVets = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const token = req.decodedToken;
+    if(token?.permission_type !== "Admin") {
+        const err = new globalError("Unauthorized to perform this action.", 401
+        ,FAIL)
+        return next(err);
+    }
+    const page = parseInt(req.query.page as string) || 1; // Default page 1
+    const limit = parseInt(req.query.limit as string) || 15; // Default 15 results per page
+    const offset = (page - 1) * limit;
+    await prisma.formerVets.findMany({
+        skip: offset,
+        take: limit,
+    }).then((result) => {
+        return res.status(200).send({
+        status: SUCCESS,
+        message: null,
+        data: result
+    });
+    });
+});
+
+export { getAllFormerVets }

--- a/src/features/Vets/controllers/get-all.vets.ts
+++ b/src/features/Vets/controllers/get-all.vets.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+const { SUCCESS, FAIL } = statusCode;
+
+const getAllVets = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const page = parseInt(req.query.page as string) || 1; // Default page 1
+    const limit = parseInt(req.query.limit as string) || 15; // Default 15 results per page
+    const offset = (page - 1) * limit;
+    await prisma.veterinarians.findMany({
+        skip: offset,
+        take: limit,
+    }).then((result) => {
+        return res.status(200).send({
+        status: SUCCESS,
+        message: null,
+        data: result
+    });
+    });
+});
+
+export { getAllVets }

--- a/src/features/Vets/controllers/login.vets.ts
+++ b/src/features/Vets/controllers/login.vets.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from "express";
+import { compare } from "bcrypt";
+import { generateJwt } from "../../../utils/generateJWT";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
+const { SUCCESS, FAIL } = statusCode;
+
+const vetsLogin = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const {email, password } = req.body;
+
+    const user = await prisma.veterinarians.findUnique({where: {email}});
+    if (!user) {
+        const err = new globalError("Invalid credentials.", 401
+        ,FAIL)
+        return next(err);
+    }
+    const matchedPassword = await compare(password, user.password!);
+    if (!matchedPassword) {
+    const err = new globalError("Invalid Credentials.", 401
+    ,FAIL)
+    return next(err);
+    }
+    if(!user.verified) {
+        res.status(401).send({
+        status: FAIL,
+        message: "This accout is yet to be verified.",
+        data: null
+    });
+    }
+    const token = await generateJwt({id: user.id, permission_type: user.permission_type});
+    return res.status(200).send({
+        status: SUCCESS,
+        message: "User sucessfully logged in.",
+        data: {
+            id: user.id,
+            email: user.email,
+            job_title: user.job_title,
+            permission_type: user.permission_type,
+            verified: user.verified
+        },
+        token
+    });
+});
+
+export { vetsLogin }

--- a/src/features/Vets/controllers/registration.vets.ts
+++ b/src/features/Vets/controllers/registration.vets.ts
@@ -1,0 +1,40 @@
+import { Request, Response, NextFunction } from "express";
+import { hash } from "bcrypt";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
+const { SUCCESS, FAIL } = statusCode;
+
+const vetsRegistration = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const {name, email, password, phone_number, job_title } = req.body;
+    const job = await prisma.jobs.findFirst({where: {title: job_title}});
+    if (!job) {
+        const err = new globalError("Please provide a valid job title [Veterinarian, Asistant or Technician].", 400
+        ,FAIL)
+        return next(err);
+    }
+    const emailFound = await prisma.veterinarians.findUnique({where: {email}});
+    if (emailFound) {
+        const err = new globalError("Email already exists.", 400
+        ,FAIL)
+        return next(err);
+    }
+    const hashedPassword = await hash(password, 10);
+    await prisma.veterinarians.create({
+        data: {
+            name,
+            job_title,
+            email,
+            password: hashedPassword,
+            phone_number,
+        }
+    })
+    return res.status(201).send({
+        status: SUCCESS,
+        message: "Account has been sucessfully created.",
+        data: null
+    });
+});
+
+export { vetsRegistration }

--- a/src/features/Vets/controllers/update.vets.ts
+++ b/src/features/Vets/controllers/update.vets.ts
@@ -1,0 +1,72 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
+const { SUCCESS, FAIL } = statusCode;
+
+const vetsUpdate = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const {id, email, password, phone_number, job_title } = req.body;
+    if(!email && !password && !phone_number && !job_title) {
+        const err = new globalError("An email, a password or a phone number is required to update an account.", 404
+        ,FAIL)
+        return next(err);
+    }
+    const token = req.decodedToken;
+    if(token?.id !== id && token?.permission_type !== "Admin") {
+        const err = new globalError("Unauthorized to perform this action.", 401
+        ,FAIL)
+        return next(err);
+    }
+    const user = await prisma.veterinarians.findUnique({where: {id}});
+    if (!user) {
+        const err = new globalError("Invalid credentials.", 401
+        ,FAIL)
+        return next(err);
+    }
+    if (password) {
+        await prisma.veterinarians.update({
+            where: {id},
+            data: {password}
+        })
+    }
+    if (email) {
+        await prisma.veterinarians.update({
+            where: {id},
+            data: {email}
+        })
+    }
+    if (phone_number) {
+        await prisma.veterinarians.update({
+            where: {id},
+            data: {phone_number}
+        })
+    }
+    if(token?.permission_type === "Admin" && job_title) {
+        const job = await prisma.jobs.findFirst({where: {title: job_title}});
+        if (!job) {
+        const err = new globalError("Please provide a valid job title [Veterinarian, Asistant or Technician].", 400
+        ,FAIL)
+        return next(err);
+        } else {
+            await prisma.veterinarians.update({
+                where: {id},
+                data:{job_title}
+            })
+        }
+    }
+    return res.status(200).send({
+        status: SUCCESS,
+        message: "Account has been sucessfully updated.",
+        data: {
+            id: user.id,
+            email: email? email : user.email,
+            phone_number: phone_number ? phone_number: user.phone_number,
+            job_title: job_title ? job_title : user.job_title,
+            permission_type: user.permission_type,
+            verified: user.verified
+        },
+    });
+});
+
+export { vetsUpdate }

--- a/src/features/Vets/controllers/verify.vets.ts
+++ b/src/features/Vets/controllers/verify.vets.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import { prisma } from "../../../config/prisma";
+import { wrapper } from "../../../middlewares/asyncWrapper";
+import { globalError } from "../../../utils/globalError";
+const { SUCCESS, FAIL } = statusCode;
+
+const vetsVerify = wrapper(async (req: Request, res: Response, next: NextFunction) => {
+    const {email} = req.body;
+    const token = req.decodedToken;
+    if(token?.permission_type !== "Admin") {
+        const err = new globalError("Unauthorized to perform this action.", 401
+        ,FAIL)
+        return next(err);
+    }
+    const user = await prisma.veterinarians.findUnique({where: {email}});
+    if (!user) {
+        const err = new globalError("Invalid user id.", 400
+        ,FAIL)
+        return next(err);
+    }
+    await prisma.veterinarians.update({
+       where:{id: user.id},
+       data: {verified: true}
+    });
+    return res.status(200).send({
+        status: SUCCESS,
+        message: "Account has been sucessfully verified.",
+        data: null
+    });
+});
+
+export { vetsVerify }

--- a/src/features/Vets/input-validation/delete.vets.schema.ts
+++ b/src/features/Vets/input-validation/delete.vets.schema.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import joi from "joi";
+const {FAIL} = statusCode
+
+
+const vetsDeleteSchema = joi.object({
+  id: joi
+    .string()
+    .id()
+    .required()
+    .messages({
+      "string.empty": "A valid id is required.",
+      "string.id": "A valid id is required.",
+    }),
+  exit_reason: joi.string().min(5).required().messages({
+    "string.empty": "A valid exit reason is required.",
+    "string.required": "A valid exit reason is required.",
+    "string.min": "Please provide a valid exit reason."
+  })
+});
+
+const vetsDeleteValidation = async (req: Request, res: Response, next: NextFunction) => {
+
+  try {
+    await vetsDeleteSchema.validateAsync(req.body);
+    next();
+  } catch (error ) {
+    if(error instanceof Error) {
+      res.status(400).send({ status: FAIL, message: error?.message })
+    }
+  }
+};
+
+export { vetsDeleteValidation };

--- a/src/features/Vets/input-validation/login.vets.schema.ts
+++ b/src/features/Vets/input-validation/login.vets.schema.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import joi from "joi";
+const {FAIL} = statusCode
+
+
+const vetsLoginSchema = joi.object({
+  email: joi
+    .string()
+    .email()
+    .required()
+    .messages({
+      "string.empty": "A valid email is required.",
+      "string.email": "A valid email is required.",
+    }),
+  password: joi
+    .string()
+    .min(6)
+    .pattern(new RegExp("^[a-zA-Z0-9]{6,30}$"))
+    .required()
+    .messages({
+      "string.empty": "A valid password is required.",
+      "string.required": "A valid password is required.",
+      "string.min": "Password must have at least 6 characters.",
+      "string.pattern": "A password must be of 6 characters or more.",
+    }),
+});
+
+const vetsLoginValidation = async (req: Request, res: Response, next: NextFunction) => {
+
+  try {
+    await vetsLoginSchema.validateAsync(req.body);
+    next();
+  } catch (error ) {
+    if(error instanceof Error) {
+      res.status(400).send({ status: FAIL, message: error?.message })
+    }
+  }
+};
+
+export { vetsLoginValidation };

--- a/src/features/Vets/input-validation/registration.vets.schema.ts
+++ b/src/features/Vets/input-validation/registration.vets.schema.ts
@@ -1,0 +1,54 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import joi from "joi";
+const {FAIL} = statusCode
+
+
+const vetsRegistrationSchema = joi.object({
+  name: joi.string().required().messages({
+    "string.empty": "Full name is required.",
+    "string.required": "Full name is required.",
+  }),
+  email: joi
+    .string()
+    .email()
+    .required()
+    .messages({
+      "string.empty": "A valid email is required.",
+      "string.email": "A valid email is required.",
+    }),
+  password: joi
+    .string()
+    .min(6)
+    .pattern(new RegExp("^[a-zA-Z0-9]{6,30}$"))
+    .required()
+    .messages({
+      "string.empty": "A valid password is required.",
+      "string.required": "A valid password is required.",
+      "string.min": "Password must have at least 6 characters.",
+      "string.pattern": "A password must be of 6 characters or more.",
+    }),
+    phone_number: joi.string().pattern(new RegExp("^[\\d\\s-]*$")).min(6).required().messages({
+      "string.empty": "A valid phone number is required.",
+      "string.required": "A valid phone number is required.",
+      "string.pattern": "A phone number can only contain digits, - or white space.",
+    }),
+    job_title: joi.string().required().messages({
+        "string.empty": "A valid job title is required.",
+      "string.required": "A valid job title is required.",
+    }),
+});
+
+const vetsRegistrationValidation = async (req: Request, res: Response, next: NextFunction) => {
+
+  try {
+    await vetsRegistrationSchema.validateAsync(req.body);
+    next();
+  } catch (error ) {
+    if(error instanceof Error) {
+      res.status(400).send({ status: FAIL, message: error?.message })
+    }
+  }
+};
+
+export { vetsRegistrationValidation };

--- a/src/features/Vets/input-validation/update.vets.schema.ts
+++ b/src/features/Vets/input-validation/update.vets.schema.ts
@@ -1,0 +1,57 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import joi from "joi";
+const {FAIL} = statusCode
+
+
+const vetsUpdateSchema = joi.object({
+  id: joi
+    .string()
+    .id()
+    .required()
+    .messages({
+      "string.empty": "A valid id is required.",
+      "string.id": "A valid id is required.",
+    }),
+    email: joi
+    .string()
+    .email()
+    .optional()
+    .messages({
+      "string.empty": "A valid email is required.",
+      "string.email": "A valid email is required.",
+      "string.optional": "A valid email is required.",
+    }),
+  password: joi
+    .string()
+    .min(6)
+    .pattern(new RegExp("^[a-zA-Z0-9]{6,30}$"))
+    .optional()
+    .messages({
+      "string.empty": "A valid password is required.",
+      "string.required": "A valid password is required.",
+      "string.min": "Password must have at least 6 characters.",
+      "string.pattern": "A password must be of 6 characters or more.",
+      "string.optional": "A valid password is required.",
+    }),
+    phone_number: joi.string().pattern(new RegExp("^[\\d\\s-]*$")).min(6).optional().messages({
+      "string.empty": "A valid phone number is required.",
+      "string.required": "A valid phone number is required.",
+      "string.pattern": "A phone number can only contain digits, - or white space.",
+      "string.optional": "A valid phone number is required.",
+    }),
+});
+
+const vetsUpdateValidation = async (req: Request, res: Response, next: NextFunction) => {
+
+  try {
+    await vetsUpdateSchema.validateAsync(req.body);
+    next();
+  } catch (error ) {
+    if(error instanceof Error) {
+      res.status(400).send({ status: FAIL, message: error?.message })
+    }
+  }
+};
+
+export { vetsUpdateValidation };

--- a/src/features/Vets/input-validation/verify.vets.schema.ts
+++ b/src/features/Vets/input-validation/verify.vets.schema.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from "express";
+import { statusCode } from "../../../utils/httpStatusCode";
+import joi from "joi";
+const {FAIL} = statusCode
+
+
+const staffVerifySchema = joi.object({
+  email: joi
+    .string()
+    .email()
+    .required()
+    .messages({
+      "string.empty": "A valid email is required.",
+      "string.email": "A valid email is required.",
+    }),
+});
+
+const vetsVerifyValidation = async (req: Request, res: Response, next: NextFunction) => {
+
+  try {
+    await staffVerifySchema.validateAsync(req.body);
+    next();
+  } catch (error ) {
+    if(error instanceof Error) {
+      res.status(400).send({ status: FAIL, message: error?.message })
+    }
+  }
+};
+
+export { vetsVerifyValidation };

--- a/src/features/Vets/routes/vets.routes.ts
+++ b/src/features/Vets/routes/vets.routes.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+// Token verification
+import { verifyToken } from "../../../middlewares/verifyToken";
+
+// Controllers
+import { getAllVets } from "../controllers/get-all.vets";
+import { getAllFormerVets } from "../controllers/get-all-former.vets";
+import { vetsRegistration } from "../controllers/registration.vets";
+import { vetsLogin } from "../controllers/login.vets";
+import { vetsUpdate } from "../controllers/update.vets";
+import { vetsDelete } from "../controllers/delete.vets";
+
+// Input validation schemas
+import { vetsRegistrationValidation } from "../input-validation/registration.vets.schema";
+import { vetsLoginValidation } from "../input-validation/login.vets.schema";
+import { vetsUpdateValidation } from "../input-validation/update.vets.schema";
+import { vetsDeleteValidation } from "../input-validation/delete.vets.schema";
+
+
+const vetsRouter = Router();
+
+vetsRouter.route("/current").get(verifyToken, getAllVets);
+
+vetsRouter.route("/former").get(verifyToken, getAllFormerVets);
+
+vetsRouter.route("/register").post(vetsRegistrationValidation, vetsRegistration);
+
+vetsRouter.route("/login").post(verifyToken, vetsLoginValidation, vetsLogin);
+
+vetsRouter.route("/").put(verifyToken, vetsUpdateValidation, vetsUpdate);
+
+vetsRouter.route("/").delete(verifyToken, vetsDeleteValidation, vetsDelete);
+
+export { vetsRouter }

--- a/src/features/Vets/routes/vets.routes.ts
+++ b/src/features/Vets/routes/vets.routes.ts
@@ -9,12 +9,14 @@ import { vetsRegistration } from "../controllers/registration.vets";
 import { vetsLogin } from "../controllers/login.vets";
 import { vetsUpdate } from "../controllers/update.vets";
 import { vetsDelete } from "../controllers/delete.vets";
+import { vetsVerify } from "../controllers/verify.vets";
 
 // Input validation schemas
 import { vetsRegistrationValidation } from "../input-validation/registration.vets.schema";
 import { vetsLoginValidation } from "../input-validation/login.vets.schema";
 import { vetsUpdateValidation } from "../input-validation/update.vets.schema";
 import { vetsDeleteValidation } from "../input-validation/delete.vets.schema";
+import { vetsVerifyValidation } from "../input-validation/verify.vets.schema";
 
 
 const vetsRouter = Router();
@@ -27,8 +29,10 @@ vetsRouter.route("/register").post(vetsRegistrationValidation, vetsRegistration)
 
 vetsRouter.route("/login").post(verifyToken, vetsLoginValidation, vetsLogin);
 
-vetsRouter.route("/").put(verifyToken, vetsUpdateValidation, vetsUpdate);
+vetsRouter.route("/verify").put(verifyToken, vetsVerifyValidation, vetsVerify);
 
-vetsRouter.route("/").delete(verifyToken, vetsDeleteValidation, vetsDelete);
+vetsRouter.route("/update").patch(verifyToken, vetsUpdateValidation, vetsUpdate);
+
+vetsRouter.route("/delete").delete(verifyToken, vetsDeleteValidation, vetsDelete);
 
 export { vetsRouter }

--- a/src/features/Vets/routes/vets.routes.ts
+++ b/src/features/Vets/routes/vets.routes.ts
@@ -31,7 +31,7 @@ vetsRouter.route("/login").post(verifyToken, vetsLoginValidation, vetsLogin);
 
 vetsRouter.route("/verify").put(verifyToken, vetsVerifyValidation, vetsVerify);
 
-vetsRouter.route("/update").patch(verifyToken, vetsUpdateValidation, vetsUpdate);
+vetsRouter.route("/update").put(verifyToken, vetsUpdateValidation, vetsUpdate);
 
 vetsRouter.route("/delete").delete(verifyToken, vetsDeleteValidation, vetsDelete);
 

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -133,3 +133,13 @@ model FormerStaff {
   exit_date    DateTime
   exit_reason  String
 }
+
+model FormerVets {
+  id           String   @id
+  name         String
+  email        String
+  phone_number String
+  job_title    String
+  exit_date    DateTime
+  exit_reason  String
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,10 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
   },
-  "include": ["src/**/*.ts", "custom.d.ts"],
+  "include": ["src/**/*.ts", "custom.d.ts", "src/docs/index.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Added the following vets routes: get current vets (can be reached by any verified account) - get former vets (protected route - only admin) - registration (unprotected route) - login (protected route - only verified accounts) - verify a vet account (protected route - only admin) - delete vet (protected route - only admin) - update vet account (protected route - only user or an admin)
- Added FormerVets model to the prisma schema 
- Added swagger documentation under /api-docs 

![Swagger documentation](https://github.com/Heba-WebDev/Vet-Care/assets/74996096/fd1a917d-ead6-40a1-921e-5846877a7edc)
