### PR TITLE
refactor(vets): delete an account 

### DIFF
--- a/src/features/Staff/__tests__/unit-tests/delete-staff.test.ts
+++ b/src/features/Staff/__tests__/unit-tests/delete-staff.test.ts
@@ -25,6 +25,9 @@ describe('Staff account deletion', () => {
       prismaMock.staff.findFirst.mockResolvedValue(staffEntityMock);
       prismaMock.formerStaff.create.mockResolvedValue(formerStaffMock);
       prismaMock.staff.delete.mockResolvedValue(formerStaffMock);
+      prismaMock.$transaction.mockImplementation(async (callback) => {
+            return callback(prismaMock);
+        });
       StaffMapper.staffEntityFromObject(staffEntityMock);
       const result = await staffDatasource.delete(member);
       expect(typeof result).toEqual('object');
@@ -34,7 +37,10 @@ describe('Staff account deletion', () => {
 
    it('should throw an error if staff id is invalid', async() => {
     prismaMock.staff.findFirst.mockResolvedValue(null);
+    prismaMock.$transaction.mockImplementation(async (callback) => {
+      return callback(prismaMock);
+    });
     await expect(staffDatasource.delete({ id: 'fake-id', exit_reason: ''})).rejects
-    .toThrow(CustomError.badRequest('Invalid credentionals'));
+    .toThrow(CustomError.badRequest('Invalid credentials'));
    });
 });

--- a/src/features/Staff/infrastructure/validation/joi-schemas/delete-staff.schema.ts
+++ b/src/features/Staff/infrastructure/validation/joi-schemas/delete-staff.schema.ts
@@ -3,15 +3,16 @@ import joi from 'joi';
 export const deleteSchema = joi.object({
   id: joi
     .string()
-    .id()
+    .uuid()
     .required()
     .messages({
       "string.empty": "A valid id is required.",
-      "string.id": "A valid id is required.",
+      "string.required": "A valid id is required.",
+      "string.uuid": "A valid id is required.",
     }),
-  exit_reason: joi.string().min(5).required().messages({
+  exit_reason: joi.string().min(5).max(50).optional().messages({
     "string.empty": "A valid exit reason is required.",
-    "string.required": "A valid exit reason is required.",
-    "string.min": "Please provide a valid exit reason."
+    "string.min": "An exit reason must be more than 5 characters.",
+    "string.max": "An exit reason must be less than 50 characters."
   })
 });

--- a/src/features/Vets/__tests__/mocks/vet.mock.ts
+++ b/src/features/Vets/__tests__/mocks/vet.mock.ts
@@ -1,5 +1,6 @@
 import { LoginVetsDto, RegisterVetsDto } from "../../domain";
 import { VetEntity } from "../../domain/entities";
+import { FormerVetEntity } from "../../domain/entities/former-vet.entity";
 
 
 export const vetRegisterDtoMock: RegisterVetsDto = {
@@ -35,3 +36,13 @@ export const vetEntityUnveriviedMock = new VetEntity(
     vetRegisterDtoMock.phone_number,
     false
 );
+
+export const formerVetMock = new FormerVetEntity(
+    vetEntityVerifiedMock.id,
+    vetEntityVerifiedMock.name,
+    vetEntityVerifiedMock.email,
+    vetEntityVerifiedMock.phone_number,
+    vetEntityVerifiedMock.job_title,
+    new Date(),
+    'Contract ended'
+)

--- a/src/features/Vets/__tests__/unit-tests/delete-vets.test.ts
+++ b/src/features/Vets/__tests__/unit-tests/delete-vets.test.ts
@@ -1,0 +1,42 @@
+import { vi, it, describe, beforeEach, expect } from 'vitest';
+import { VetMapper, VetsDatasourceImpl } from '../../infrastructure';
+import { prismaMock } from '../../../../tests/mocks';
+import { formerVetMock, vetEntityVerifiedMock } from '../mocks/vet.mock';
+import { CustomError } from '../../../../domain';
+
+
+describe('Vets account deletion', () => {
+    let VetsDatasource: VetsDatasourceImpl;
+
+    beforeEach(() => {
+        VetsDatasource = new VetsDatasourceImpl(prismaMock);
+        vi.clearAllMocks();
+    });
+
+    it('should delete a vet member', async() => {
+      const member = {
+        id: vetEntityVerifiedMock.id,
+        exit_reason: 'Contract ended'
+      }
+      prismaMock.veterinarians.findFirst.mockResolvedValue(vetEntityVerifiedMock);
+      prismaMock.formerVets.create.mockResolvedValue(formerVetMock);
+      prismaMock.veterinarians.delete.mockResolvedValue(vetEntityVerifiedMock);
+      prismaMock.$transaction.mockImplementation(async (callback) => {
+            return callback(prismaMock);
+        });
+      VetMapper.vetEntityFromObject(vetEntityVerifiedMock);
+      const result = await VetsDatasource.delete(member);
+      expect(typeof result).toEqual('object');
+      expect(prismaMock.veterinarians.delete).toHaveBeenCalledOnce();
+      expect(prismaMock.formerVets.create).toHaveBeenCalledOnce();
+    });
+
+   it('should throw an error if staff id is invalid', async() => {
+    prismaMock.veterinarians.findFirst.mockResolvedValue(null);
+    prismaMock.$transaction.mockImplementation(async (callback) => {
+      return callback(prismaMock);
+    });
+    await expect(VetsDatasource.delete({ id: 'fake-id', exit_reason: ''})).rejects
+    .toThrow(CustomError.badRequest('Invalid credentials'));
+   });
+});

--- a/src/features/Vets/domain/datasources/vets.datasource.ts
+++ b/src/features/Vets/domain/datasources/vets.datasource.ts
@@ -1,8 +1,9 @@
-import { RegisterVetsDto, VerifyVetDto, LoginVetsDto } from "../dtos";
+import { RegisterVetsDto, VerifyVetDto, LoginVetsDto, DeleteVetsDto } from "../dtos";
 import { VetEntity } from "../entities";
 
 export abstract class VetsDatasource {
     abstract register(vetsDto: RegisterVetsDto): Promise<VetEntity | null>
     abstract verify(vetsDto: VerifyVetDto): Promise<VetEntity | null>
     abstract login(vetsDto: LoginVetsDto): Promise<VetEntity | null>
+    abstract delete(vetsDto: DeleteVetsDto): Promise<VetEntity | null>
 }

--- a/src/features/Vets/domain/dtos/delete-vets.dto.ts
+++ b/src/features/Vets/domain/dtos/delete-vets.dto.ts
@@ -1,0 +1,17 @@
+import { DeleteSchema } from "../../infrastructure";
+
+
+export class DeleteVetsDto {
+    private constructor(
+        public id: string,
+        public exit_reason: string
+    ) {}
+
+    static delete(object: {[key: string]: any}): [string?, DeleteVetsDto?] {
+        const { id, exit_reason } = object;
+        const deleteDto = new DeleteVetsDto(id, exit_reason);
+        const { error } = DeleteSchema.validate(deleteDto);
+        if (error) return [error.message, undefined]
+        return [undefined, deleteDto]
+    }
+}

--- a/src/features/Vets/domain/dtos/index.ts
+++ b/src/features/Vets/domain/dtos/index.ts
@@ -1,3 +1,4 @@
 export * from './register-vets.dto'
 export * from './verify-vets.dto'
 export * from './login-vets.dto'
+export * from './delete-vets.dto'

--- a/src/features/Vets/domain/entities/former-vet.entity.ts
+++ b/src/features/Vets/domain/entities/former-vet.entity.ts
@@ -1,0 +1,13 @@
+
+
+export class FormerVetEntity {
+    constructor(
+        public id: string,
+        public name: string,
+        public email: string,
+        public phone_number: string,
+        public job_title: string,
+        public exit_date: Date,
+        public exit_reason: string,
+    ) {}
+}

--- a/src/features/Vets/domain/interfaces/index.ts
+++ b/src/features/Vets/domain/interfaces/index.ts
@@ -1,5 +1,5 @@
 import { payload } from "../../../../interfaces";
-import { RegisterVetsDto, VerifyVetDto, LoginVetsDto } from "../dtos";
+import { RegisterVetsDto, VerifyVetDto, LoginVetsDto, DeleteVetsDto } from "../dtos";
 export type SignToken = (payload: payload, duration?: string) => Promise<string | null>;
 
 
@@ -14,4 +14,8 @@ export interface VerifyVetsUseCase {
 
 export interface LoginVetsUseCase {
     execute( verifyVets: LoginVetsDto): Promise<any>;
+}
+
+export interface DeleteVetsUseCase {
+    execuse( deleteVets: DeleteVetsDto): Promise<any>
 }

--- a/src/features/Vets/domain/repositories/vets.repository.ts
+++ b/src/features/Vets/domain/repositories/vets.repository.ts
@@ -1,8 +1,9 @@
-import { RegisterVetsDto, VerifyVetDto, LoginVetsDto } from "../dtos";
+import { RegisterVetsDto, VerifyVetDto, LoginVetsDto, DeleteVetsDto } from "../dtos";
 import { VetEntity } from "../entities";
 
 export abstract class VetsRepository {
     abstract register(vetsDto: RegisterVetsDto): Promise<VetEntity | null>
     abstract verify(vetsDto: VerifyVetDto): Promise<VetEntity | null>
     abstract login(vetsDto: LoginVetsDto): Promise<VetEntity | null>
+    abstract delete(vetsDto: DeleteVetsDto): Promise<VetEntity | null>
 }

--- a/src/features/Vets/domain/use-cases/delete-vets.use-case.ts
+++ b/src/features/Vets/domain/use-cases/delete-vets.use-case.ts
@@ -1,0 +1,18 @@
+import { DeleteVetsDto } from "../dtos";
+import { DeleteVetsUseCase } from "../interfaces";
+import { VetsRepository } from "../repositories";
+
+
+export class DeleteVets implements DeleteVetsUseCase {
+    constructor(
+        private readonly repo: VetsRepository,
+    ) {}
+    async execuse(dto: DeleteVetsDto): Promise<any> {
+        await this.repo.delete(dto);
+       return {
+            message: 'Vet succssfully deleted',
+            data: null
+        }
+    }
+
+}

--- a/src/features/Vets/domain/use-cases/index.ts
+++ b/src/features/Vets/domain/use-cases/index.ts
@@ -1,3 +1,4 @@
 export * from './register-vets.use-case'
 export * from './verify-vets.use-case'
 export * from './login-vets.use-case'
+export * from './delete-vets.use-case'

--- a/src/features/Vets/infrastructure/repositories/vets.repository.ts
+++ b/src/features/Vets/infrastructure/repositories/vets.repository.ts
@@ -1,4 +1,4 @@
-import { LoginVetsDto, RegisterVetsDto, VerifyVetDto } from "../../domain";
+import { DeleteVetsDto, LoginVetsDto, RegisterVetsDto, VerifyVetDto } from "../../domain";
 import { VetsDatasource } from "../../domain/datasources/vets.datasource";
 import { VetEntity } from "../../domain/entities";
 import { VetsRepository } from "../../domain/repositories";
@@ -21,5 +21,9 @@ export class VetsRepositoryImpl extends VetsRepository {
 
     login(vetsDto: LoginVetsDto): Promise<VetEntity | null> {
         return this.datasource.login(vetsDto);
+    }
+
+    delete(vetsDto: DeleteVetsDto): Promise<VetEntity | null> {
+        return this.datasource.delete(vetsDto);
     }
 }

--- a/src/features/Vets/infrastructure/validation/joi-schemas/delete.schema.ts
+++ b/src/features/Vets/infrastructure/validation/joi-schemas/delete.schema.ts
@@ -1,0 +1,14 @@
+import joi from 'joi';
+
+export const DeleteSchema = joi.object({
+    id: joi.string().uuid().required().messages({
+        "string.empty": "An id is required.",
+        "string.uuid": "A valid id is required.",
+        "string.required": "An id is required.",
+    }),
+    exit_reason: joi.string().min(5).max(50).optional().messages({
+        "string.empty": "An exit reason is required.",
+        "string.min": "A meaningful exist reason is required",
+        "string.max": "An exist reason can't exceed 50 characters"
+    })
+    });

--- a/src/features/Vets/infrastructure/validation/joi-schemas/index.ts
+++ b/src/features/Vets/infrastructure/validation/joi-schemas/index.ts
@@ -1,3 +1,4 @@
 export * from './register.schema'
 export * from './verify.schema'
 export * from './login.schema'
+export * from './delete.schema'

--- a/src/features/Vets/presentation/controller.vets.ts
+++ b/src/features/Vets/presentation/controller.vets.ts
@@ -3,7 +3,8 @@ import { BaseController } from "../../../presentation/base.controller";
 import { LoginVets, RegisterVets } from "../domain/use-cases";
 import { VetsRepository } from "../domain/repositories";
 import { VerifyVets } from "../domain/use-cases/verify-vets.use-case";
-import { RegisterVetsDto, VerifyVetDto, LoginVetsDto } from "../domain";
+import { RegisterVetsDto, VerifyVetDto, LoginVetsDto, DeleteVetsDto } from "../domain";
+import { DeleteVets } from "../domain/use-cases/delete-vets.use-case";
 
 
 export class VetsController extends BaseController {
@@ -39,5 +40,11 @@ export class VetsController extends BaseController {
 
     update = (req: Request, res: Response) => {}
 
-    delete = (req: Request, res: Response) => {}
+    delete = (req: Request, res: Response) => {
+        const [error, deleteDto] = DeleteVetsDto.delete(req.body);
+        if (error) return res.status(400).send({ error });
+        new DeleteVets(this.vetsRepo).execuse(deleteDto!)
+        .then((data) => res.json(data))
+        .catch((error) => this.handleError(error, res))
+    }
 }

--- a/src/features/Vets/presentation/routes.vets.ts
+++ b/src/features/Vets/presentation/routes.vets.ts
@@ -16,6 +16,7 @@ export class VetsRoutes {
         router.post('/register', controller.register)
         router.patch('/verify', [AuthMiddlewear.authenticated, AuthMiddlewear.authorized], controller.verify)
         router.post('/login', controller.login)
+        router.delete('/delete',[AuthMiddlewear.authenticated, AuthMiddlewear.authorized], controller.delete)
 
         return router;
     }

--- a/src/tests/mocks/prisma.mock.ts
+++ b/src/tests/mocks/prisma.mock.ts
@@ -16,6 +16,7 @@ export const prismaMock = {
         findFirst: vi.fn(),
         create: vi.fn(),
         update: vi.fn(),
+        delete: vi.fn(),
     },
     owners: {},
     pets: {},
@@ -30,7 +31,10 @@ export const prismaMock = {
         create: vi.fn(),
         findMany: vi.fn(),
     },
-    formerVets: {},
+    formerVets: {
+        create: vi.fn(),
+        findMany: vi.fn(),
+    },
     // $on: vi.fn(),
     // $connect: vi.fn(),
     // $disconnect: vi.fn(),
@@ -39,6 +43,6 @@ export const prismaMock = {
     // $executeRawUnsafe: vi.fn(),
     // $queryRaw: vi.fn(),
     // $queryRawUnsafe: vi.fn(),
-    // $transaction: vi.fn(),
+    $transaction: vi.fn(),
     // $extends: vi.fn(),
 }


### PR DESCRIPTION
- [x] Refactored delete a vet account 
- [x] Both a verified and an unverified account can be deleted. When an account is verified, before the record deletion it gets added to former vet table in the database
- [x] Use transaction to grantee data integrity and have a safe deletion for the records
- [x] Made the same change in Staff to have a universal solution for former staff and vets
- [x] Added unit tests 
- [x] Screenshots: 
![Screenshot 2024-08-10 at 12 52 16 PM](https://github.com/user-attachments/assets/c4a68c2e-ab7e-4e3d-a2b3-a8b5b734add8)
![Screenshot 2024-08-10 at 2 10 10 PM](https://github.com/user-attachments/assets/51719936-9b11-4fd1-9522-8df186ad2213)

