### PR TITLE
fix(vets/staff): update an account

### DIFF
--- a/src/features/Staff/domain/dtos/update-staff.dto.ts
+++ b/src/features/Staff/domain/dtos/update-staff.dto.ts
@@ -8,8 +8,8 @@ export class UpdateStaffDto {
     public phone_number: string,
   ) {}
 
-  static upate(object: { [key: string]: string }): [string?, UpdateStaffDto?] {
-    const { id, email, password, phone_number } = object;
+  static update(id: string, object: { [key: string]: string }): [string?, UpdateStaffDto?] {
+    const { email, password, phone_number } = object;
     if (!email && !password && !phone_number)
       return ['Provide an email, a password or a phone number to update', undefined];
     const staffDto = new UpdateStaffDto(id, email, password, phone_number);

--- a/src/features/Staff/infrastructure/validation/joi-schemas/update-staff.schema.ts
+++ b/src/features/Staff/infrastructure/validation/joi-schemas/update-staff.schema.ts
@@ -1,14 +1,9 @@
 import joi from 'joi';
 
 export const updateSchema = joi.object({
-  id: joi.string().id().required().messages({
+  id: joi.string().uuid().required().messages({
     'string.empty': 'A valid id is required.',
     'string.id': 'A valid id is required.',
-  }),
-
-  name: joi.string().optional().messages({
-    'string.empty': 'Full name is required.',
-    'string.required': 'Full name is required.',
   }),
 
   email: joi.string().email().optional().messages({
@@ -29,10 +24,5 @@ export const updateSchema = joi.object({
     'string.required': 'A valid phone number is required.',
     'string.pattern': 'A phone number can only contain digits, - or white space.',
     'string.optional': 'A valid phone number is required.',
-  }),
-
-  job_title: joi.string().optional().messages({
-    'string.empty': 'A valid job title is required.',
-    'string.optional': 'A valid job title is required.',
   }),
 });

--- a/src/features/Staff/presentation/controller.staff.ts
+++ b/src/features/Staff/presentation/controller.staff.ts
@@ -81,7 +81,7 @@ export class StaffController extends BaseController {
   };
 
   update = (req: Request, res: Response) => {
-    const [error, staffDto] = UpdateStaffDto.upate(req.body);
+    const [error, staffDto] = UpdateStaffDto.update(req.params.id, req.body);
     if (error) return res.status(400).send({ error });
     new UpdateStaff(this.staffRepo)
       .execute(staffDto!)

--- a/src/features/Staff/presentation/routes.staff.ts
+++ b/src/features/Staff/presentation/routes.staff.ts
@@ -29,7 +29,7 @@ export class StaffRoutes {
       controller.getAllFormer,
     );
     router.patch(
-      '/update',
+      '/:id',
       [AuthMiddleware.authenticated, AuthMiddleware.updateAuthorized],
       controller.update,
     );

--- a/src/features/Vets/domain/dtos/update-vets.dto.ts
+++ b/src/features/Vets/domain/dtos/update-vets.dto.ts
@@ -2,14 +2,14 @@ import { VetsInputValidation } from '../../infrastructure';
 
 export class UpdateVetsDto {
   private constructor(
-    public id: string,
-    public email: string,
-    public password: string,
-    public phone_number: string,
+    public readonly id: string,
+    public readonly email?: string,
+    public readonly password?: string,
+    public readonly phone_number?: string,
   ) {}
 
-  static upate(object: { [key: string]: string }): [string?, UpdateVetsDto?] {
-    const { id, email, password, phone_number } = object;
+  static upate(id: string, object: { [key: string]: string }): [string?, UpdateVetsDto?] {
+    const { email, password, phone_number } = object;
     if (!email && !password && !phone_number)
       return ['Provide an email, a password or a phone number to update', undefined];
     const vetsDto = new UpdateVetsDto(id, email, password, phone_number);

--- a/src/features/Vets/infrastructure/validation/joi-schemas/update.schema.ts
+++ b/src/features/Vets/infrastructure/validation/joi-schemas/update.schema.ts
@@ -6,11 +6,6 @@ export const updateSchema = joi.object({
     'string.uuid': 'A valid id is required.',
   }),
 
-  name: joi.string().optional().messages({
-    'string.empty': 'Full name is required.',
-    'string.required': 'Full name is required.',
-  }),
-
   email: joi.string().email().optional().messages({
     'string.empty': 'A valid email is required.',
     'string.email': 'A valid email is required.',
@@ -29,10 +24,5 @@ export const updateSchema = joi.object({
     'string.required': 'A valid phone number is required.',
     'string.pattern': 'A phone number can only contain digits, - or white space.',
     'string.optional': 'A valid phone number is required.',
-  }),
-
-  job_title: joi.string().optional().messages({
-    'string.empty': 'A valid job title is required.',
-    'string.optional': 'A valid job title is required.',
   }),
 });

--- a/src/features/Vets/presentation/controller.vets.ts
+++ b/src/features/Vets/presentation/controller.vets.ts
@@ -52,7 +52,7 @@ export class VetsController extends BaseController {
   };
 
   update = (req: Request, res: Response) => {
-    const [error, updateDto] = UpdateVetsDto.upate(req.body);
+    const [error, updateDto] = UpdateVetsDto.upate(req.params.id, req.body);
     if (error) return res.status(400).send({ error });
     new UpdateVets(this.vetsRepo)
       .execute(updateDto!)

--- a/src/features/Vets/presentation/routes.vets.ts
+++ b/src/features/Vets/presentation/routes.vets.ts
@@ -18,7 +18,7 @@ export class VetsRoutes {
     );
     router.post('/login', controller.login);
     router.patch(
-      '/update',
+      '/:id',
       [AuthMiddleware.authenticated, AuthMiddleware.updateAuthorized],
       controller.update,
     );


### PR DESCRIPTION
## Tasks:
- [x] Refactored the updateStaff endpoint to retrieve the id from the URL (/api/v1/staff/:id).
- [x] Refactored the updateVets endpoint to retrieve the id from the URL (/api/v1/vets/:id).
- [x] Updated the DTOs for Staff and Vets to remove the id field from the request body.
- [x] Successfully ran all unit tests after the changes.

Closes #47 
[Unify Update Endpoint Patterns: Move ID from Request Body to URL for Staff and Vets](https://github.com/Heba-WebDev/Vet-Care/issues/47)