### PR TITLE
feat: working days

### DIFF
--- a/src/__tests__/__mocks__/prisma.mock.ts
+++ b/src/__tests__/__mocks__/prisma.mock.ts
@@ -47,6 +47,13 @@ export const prismaMock: MockPrismaClient = {
     update: vi.fn(),
   },
   permissions: {},
+  workingDays: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
   appointments: {},
   services: {
     findFirst: vi.fn(),

--- a/src/data/prisma/migrations/20240923105456_working_days/migration.sql
+++ b/src/data/prisma/migrations/20240923105456_working_days/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "Day" AS ENUM ('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday');
+
+-- CreateTable
+CREATE TABLE "WorkingDays" (
+    "id" SERIAL NOT NULL,
+    "day" "Day" NOT NULL,
+
+    CONSTRAINT "WorkingDays_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkingDays_day_key" ON "WorkingDays"("day");

--- a/src/data/prisma/migrations/20240923110205_working_days_active/migration.sql
+++ b/src/data/prisma/migrations/20240923110205_working_days_active/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkingDays" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true;

--- a/src/data/prisma/schema.prisma
+++ b/src/data/prisma/schema.prisma
@@ -48,6 +48,16 @@ enum Gender {
   Female
 }
 
+enum Day {
+  Monday
+  Tuesday
+  Wednesday
+  Thursday
+  Friday
+  Saturday
+  Sunday
+}
+
 model Staff {
   id              String      @id @default(uuid())
   name            String
@@ -117,6 +127,12 @@ model Permissions {
   type          Permission      @unique
   staff         Staff[]
   veterinarians Veterinarians[]
+}
+
+model WorkingDays {
+  id Int @id @default(autoincrement())
+  day Day @unique
+  active Boolean @default(true)
 }
 
 model Appointments {

--- a/src/data/prisma/seed/seed.ts
+++ b/src/data/prisma/seed/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Animal, Permission, Gender } from '@prisma/client';
+import { PrismaClient, Animal, Permission, Gender, Day } from '@prisma/client';
 import { Title } from '../enums';
 import { logger } from '../../../infrastructure';
 import { bcryptAdapter } from '../../../config';
@@ -200,6 +200,29 @@ class Seeder {
       logger.info('Jobs table has been seeded successfully.');
     } else {
       logger.info('Services table already contains data.');
+    }
+
+    // Working Days
+    const workingDaysCount = await this.prisma.workingDays.count();
+    if (workingDaysCount === 0) {
+      const days = [
+        { name: Day.Monday },
+        { name: Day.Tuesday },
+        { name: Day.Wednesday },
+        { name: Day.Thursday },
+        { name: Day.Friday },
+        { name: Day.Saturday },
+        { name: Day.Sunday },
+      ];
+      for (const day of days) {
+        await this.prisma.workingDays.create({
+          data: {
+            day: day.name,
+          },
+        });
+      }
+    } else {
+      logger.info('Working Days table already contains data.');
     }
 
     logger.info('Data has been seeded successfully.');

--- a/src/features/Working-Days/__tests__/mocks/working-days.mock.ts
+++ b/src/features/Working-Days/__tests__/mocks/working-days.mock.ts
@@ -1,0 +1,19 @@
+import { Day } from '@prisma/client';
+import { UpdateWorkingDayDto, WorkingDayEntity } from '../../domain';
+
+export const defaultWorkDayMock: WorkingDayEntity = {
+  id: 5,
+  day: Day.Friday,
+  active: true,
+};
+
+export const updateWorkDayMockDto: UpdateWorkingDayDto = {
+  id: 1,
+  active: false,
+};
+
+export const updatedWorkDayMock: WorkingDayEntity = {
+  id: 5,
+  day: Day.Friday,
+  active: true,
+};

--- a/src/features/Working-Days/__tests__/unit-tests/update-working-day.test.ts
+++ b/src/features/Working-Days/__tests__/unit-tests/update-working-day.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prismaMock } from '../../../../__tests__/__mocks__';
+import { PrismaClient } from '@prisma/client';
+import { WorkingDaysDatasourceImpl } from '../../infrastructure';
+import {
+  defaultWorkDayMock,
+  updatedWorkDayMock,
+  updateWorkDayMockDto,
+} from '../mocks/working-days.mock';
+import { CustomError } from '../../../../domain';
+
+describe('Update a working day', () => {
+  let datasource: WorkingDaysDatasourceImpl;
+  beforeEach(() => {
+    datasource = new WorkingDaysDatasourceImpl(prismaMock as unknown as PrismaClient);
+    vi.clearAllMocks();
+  });
+
+  it('should successfully update a working day', async () => {
+    prismaMock.$transaction.mockImplementation(async (callback) => {
+      return callback(prismaMock);
+    });
+    prismaMock.workingDays.findFirst?.mockReturnValueOnce(defaultWorkDayMock);
+    prismaMock.workingDays.update?.mockReturnValueOnce(updatedWorkDayMock);
+    const result = await datasource.update({
+      id: updateWorkDayMockDto.id,
+      active: updateWorkDayMockDto.active,
+    });
+    expect(typeof result).toEqual('object');
+    expect(result?.active).toEqual(updatedWorkDayMock.active);
+    expect(result?.id).toEqual(defaultWorkDayMock.id);
+  });
+
+  it("should throw an error if the working day can't be found", async () => {
+    prismaMock.$transaction.mockImplementation(async (callback) => {
+      return callback(prismaMock);
+    });
+    prismaMock.workingDays.findFirst?.mockReturnValueOnce(null);
+    await expect(datasource.update({ id: 12, active: false })).rejects.toThrow(
+      CustomError.badRequest('No working day found'),
+    );
+  });
+});

--- a/src/features/Working-Days/domain/datasources/index.ts
+++ b/src/features/Working-Days/domain/datasources/index.ts
@@ -1,0 +1,1 @@
+export * from './working-days.datasource';

--- a/src/features/Working-Days/domain/datasources/working-days.datasource.ts
+++ b/src/features/Working-Days/domain/datasources/working-days.datasource.ts
@@ -1,0 +1,6 @@
+import { UpdateWorkingDayDto } from '../dtos';
+import { WorkingDayEntity } from '../entities';
+
+export abstract class WorkingDaysDatasource {
+  abstract update(dto: UpdateWorkingDayDto): Promise<WorkingDayEntity | null>;
+}

--- a/src/features/Working-Days/domain/dtos/index.ts
+++ b/src/features/Working-Days/domain/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './update-working-day.dto';

--- a/src/features/Working-Days/domain/dtos/update-working-day.dto.ts
+++ b/src/features/Working-Days/domain/dtos/update-working-day.dto.ts
@@ -1,0 +1,18 @@
+import { ParsedQs } from 'qs';
+import { WorkingDaysInputValidation } from '../../infrastructure';
+
+export class UpdateWorkingDayDto {
+  private constructor(
+    public id: number,
+    public active: boolean,
+  ) {}
+
+  static update(object: ParsedQs): [string?, UpdateWorkingDayDto?] {
+    const { id, active } = object;
+    if (active !== 'true' && active !== 'false') return ['Active must be true or false', undefined];
+    const dto = new UpdateWorkingDayDto(parseInt(id as string), active === 'true' ? true : false);
+    const error = new WorkingDaysInputValidation().update(dto);
+    if (error) return [error, undefined];
+    return [undefined, dto];
+  }
+}

--- a/src/features/Working-Days/domain/entities/index.ts
+++ b/src/features/Working-Days/domain/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './working-day.entity';

--- a/src/features/Working-Days/domain/entities/working-day.entity.ts
+++ b/src/features/Working-Days/domain/entities/working-day.entity.ts
@@ -1,0 +1,7 @@
+export class WorkingDayEntity {
+  constructor(
+    public id: number,
+    public day: string,
+    public active: boolean,
+  ) {}
+}

--- a/src/features/Working-Days/domain/index.ts
+++ b/src/features/Working-Days/domain/index.ts
@@ -1,0 +1,5 @@
+export * from './dtos';
+export * from './datasources';
+export * from './entities';
+export * from './repositories';
+export * from './use-cases';

--- a/src/features/Working-Days/domain/interfaces/index.ts
+++ b/src/features/Working-Days/domain/interfaces/index.ts
@@ -1,0 +1,14 @@
+import { UpdateWorkingDayDto } from '../dtos';
+import { WorkingDayEntity } from '../entities';
+
+// types
+export type WorkingDaysStandardResponse = {
+  status: string;
+  message: string | null;
+  data: WorkingDayEntity | null;
+};
+
+// interfaces
+export interface UpdateWorkingDayUseCase {
+  execute(dto: UpdateWorkingDayDto): Promise<WorkingDaysStandardResponse>;
+}

--- a/src/features/Working-Days/domain/repositories/index.ts
+++ b/src/features/Working-Days/domain/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './working-days.repository';

--- a/src/features/Working-Days/domain/repositories/working-days.repository.ts
+++ b/src/features/Working-Days/domain/repositories/working-days.repository.ts
@@ -1,0 +1,6 @@
+import { UpdateWorkingDayDto } from '../dtos';
+import { WorkingDayEntity } from '../entities';
+
+export abstract class WorkingDaysRepository {
+  abstract update(dto: UpdateWorkingDayDto): Promise<WorkingDayEntity | null>;
+}

--- a/src/features/Working-Days/domain/use-cases/index.ts
+++ b/src/features/Working-Days/domain/use-cases/index.ts
@@ -1,0 +1,1 @@
+export * from './update-working-day.use-case';

--- a/src/features/Working-Days/domain/use-cases/update-working-day.use-case.ts
+++ b/src/features/Working-Days/domain/use-cases/update-working-day.use-case.ts
@@ -1,0 +1,15 @@
+import { UpdateWorkingDayDto } from '../dtos';
+import { UpdateWorkingDayUseCase, WorkingDaysStandardResponse } from '../interfaces';
+import { WorkingDaysRepository } from '../repositories';
+
+export class UpdateWorkingDay implements UpdateWorkingDayUseCase {
+  constructor(private readonly repo: WorkingDaysRepository) {}
+  async execute(dto: UpdateWorkingDayDto): Promise<WorkingDaysStandardResponse> {
+    const workingDay = await this.repo.update(dto);
+    return {
+      status: 'success',
+      message: 'Working day successfully updated',
+      data: workingDay,
+    };
+  }
+}

--- a/src/features/Working-Days/index.ts
+++ b/src/features/Working-Days/index.ts
@@ -1,0 +1,1 @@
+export * from './presentation';

--- a/src/features/Working-Days/infrastructure/datasources/index.ts
+++ b/src/features/Working-Days/infrastructure/datasources/index.ts
@@ -1,0 +1,1 @@
+export * from './working-days.datasource';

--- a/src/features/Working-Days/infrastructure/datasources/working-days.datasource.ts
+++ b/src/features/Working-Days/infrastructure/datasources/working-days.datasource.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from '@prisma/client';
+import { UpdateWorkingDayDto, WorkingDayEntity, WorkingDaysDatasource } from '../../domain';
+import { prisma } from '../../../../data';
+import { logger } from '../../../../infrastructure';
+import { CustomError } from '../../../../domain';
+import { WorkingDayMapper } from '../mappers';
+
+export class WorkingDaysDatasourceImpl implements WorkingDaysDatasource {
+  private readonly _prisma: PrismaClient;
+  constructor(orm: PrismaClient = prisma) {
+    this._prisma = orm;
+  }
+
+  async update(dto: UpdateWorkingDayDto): Promise<WorkingDayEntity | null> {
+    const { id, active } = dto;
+    try {
+      const workingDay = await this._prisma.$transaction(async (prisma) => {
+        const exists = await prisma.workingDays.findFirst({ where: { id } });
+        if (!exists) throw CustomError.badRequest('No working day found');
+        return prisma.workingDays.update({
+          where: {
+            id,
+          },
+          data: {
+            active,
+          },
+        });
+      });
+      return WorkingDayMapper.workingDayEntityFromObject(workingDay);
+    } catch (error) {
+      logger.error(error);
+      if (error instanceof CustomError) throw error;
+      throw CustomError.internalServerError();
+    }
+  }
+}

--- a/src/features/Working-Days/infrastructure/index.ts
+++ b/src/features/Working-Days/infrastructure/index.ts
@@ -1,0 +1,3 @@
+export * from './validation';
+export * from './repositories';
+export * from './datasources';

--- a/src/features/Working-Days/infrastructure/mappers/index.ts
+++ b/src/features/Working-Days/infrastructure/mappers/index.ts
@@ -1,0 +1,1 @@
+export * from './working-day.mapper';

--- a/src/features/Working-Days/infrastructure/mappers/working-day.mapper.ts
+++ b/src/features/Working-Days/infrastructure/mappers/working-day.mapper.ts
@@ -1,0 +1,14 @@
+import { CustomError } from '../../../../domain';
+import { WorkingDayEntity } from '../../domain';
+
+export class WorkingDayMapper {
+  static workingDayEntityFromObject(workingDayEntity: WorkingDayEntity) {
+    const { id, day, active } = workingDayEntity;
+
+    if (!id) throw CustomError.badRequest('Missing id');
+    if (!day) throw CustomError.badRequest('Missing day');
+    if (typeof active !== 'boolean') throw CustomError.badRequest('Missing active');
+
+    return new WorkingDayEntity(id, day, active);
+  }
+}

--- a/src/features/Working-Days/infrastructure/repositories/index.ts
+++ b/src/features/Working-Days/infrastructure/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './working-days.repository';

--- a/src/features/Working-Days/infrastructure/repositories/working-days.repository.ts
+++ b/src/features/Working-Days/infrastructure/repositories/working-days.repository.ts
@@ -1,0 +1,11 @@
+import { UpdateWorkingDayDto, WorkingDayEntity, WorkingDaysRepository } from '../../domain';
+
+export class WorkingDaysRepositoryImpl extends WorkingDaysRepository {
+  constructor(private readonly repo: WorkingDaysRepository) {
+    super();
+  }
+
+  update(dto: UpdateWorkingDayDto): Promise<WorkingDayEntity | null> {
+    return this.repo.update(dto);
+  }
+}

--- a/src/features/Working-Days/infrastructure/validation/index.ts
+++ b/src/features/Working-Days/infrastructure/validation/index.ts
@@ -1,0 +1,1 @@
+export * from './working-days.validation.impl';

--- a/src/features/Working-Days/infrastructure/validation/joi-schemas/index.ts
+++ b/src/features/Working-Days/infrastructure/validation/joi-schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './update-working-day.schema';

--- a/src/features/Working-Days/infrastructure/validation/joi-schemas/update-working-day.schema.ts
+++ b/src/features/Working-Days/infrastructure/validation/joi-schemas/update-working-day.schema.ts
@@ -1,0 +1,12 @@
+import joi from 'joi';
+
+export const updateWorkingDaySchema = joi.object({
+  id: joi.number().required().messages({
+    'id.number': 'A valid working day id is required',
+    'id.required': 'An working day id is required',
+  }),
+  active: joi.boolean().required().messages({
+    'boolean.base': 'Active must be either true or false',
+    'boolean.required': 'Active is required',
+  }),
+});

--- a/src/features/Working-Days/infrastructure/validation/working-days.validation.impl.ts
+++ b/src/features/Working-Days/infrastructure/validation/working-days.validation.impl.ts
@@ -1,0 +1,10 @@
+import { UpdateWorkingDayDto } from '../../domain';
+import { updateWorkingDaySchema } from './joi-schemas';
+
+export class WorkingDaysInputValidation {
+  update(workingDayDto: UpdateWorkingDayDto): string | null {
+    const { error } = updateWorkingDaySchema.validate(workingDayDto);
+    if (error) return error.message;
+    return null;
+  }
+}

--- a/src/features/Working-Days/presentation/controller.working-days.ts
+++ b/src/features/Working-Days/presentation/controller.working-days.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+import { BaseController } from '../../../presentation/base.controller';
+import { UpdateWorkingDay, UpdateWorkingDayDto, WorkingDaysRepository } from '../domain';
+
+export class WorkingDaysController extends BaseController {
+  constructor(private readonly repo: WorkingDaysRepository) {
+    super();
+  }
+  update = (req: Request, res: Response) => {
+    const [error, dto] = UpdateWorkingDayDto.update(req.query);
+    if (error) return res.status(400).send({ error });
+    new UpdateWorkingDay(this.repo)
+      .execute(dto!)
+      .then((data) => res.send(data))
+      .catch((error) => this.handleError(error, res));
+  };
+}

--- a/src/features/Working-Days/presentation/index.ts
+++ b/src/features/Working-Days/presentation/index.ts
@@ -1,0 +1,1 @@
+export * from './routes.working-days';

--- a/src/features/Working-Days/presentation/routes.working-days.ts
+++ b/src/features/Working-Days/presentation/routes.working-days.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { WorkingDaysDatasourceImpl, WorkingDaysRepositoryImpl } from '../infrastructure';
+import { WorkingDaysController } from './controller.working-days';
+import { AuthMiddleware } from '../../../presentation';
+
+export class WorkingDaysRoutes {
+  static get routes(): Router {
+    const router = Router();
+    const datasouce = new WorkingDaysDatasourceImpl();
+    const repository = new WorkingDaysRepositoryImpl(datasouce);
+    const controller = new WorkingDaysController(repository);
+
+    router.patch('/', [AuthMiddleware.authenticated, AuthMiddleware.authorized], controller.update);
+
+    return router;
+  }
+}

--- a/src/presentation/routes.ts
+++ b/src/presentation/routes.ts
@@ -5,6 +5,7 @@ import { OwnersRoutes } from '../features/Owners';
 import { AnimalsRoutes } from '../features/Animals/presentation';
 import { PetsRoutes } from '../features/Pets/presentaiton';
 import { ServicesRoutes } from '../features/Services/presentation';
+import { WorkingDaysRoutes } from '../features/Working-Days';
 
 export class AppRoutes {
   static get routes(): Router {
@@ -15,6 +16,7 @@ export class AppRoutes {
     router.use('/api/v2/animals', AnimalsRoutes.routes);
     router.use('/api/v2', PetsRoutes.routes);
     router.use('/api/v2/services', ServicesRoutes.routes);
+    router.use('/api/v2/working-days', WorkingDaysRoutes.routes);
     return router;
   }
 }


### PR DESCRIPTION
## Tasks
- [x] Added /api/v2/working-days resource
- [x] Added an endpoint to update working days
- [x] Only authenticated and authorized users can access the endpoint 
- [x] Added a script to seed the working days table
- [x] Added the migration for the new table
- [x] Added unit tests for updating g a working day
- [x] Ran lint and format scripts
- [x] Screenshot/s
![Screenshot 2024-09-23 at 1 55 35 PM](https://github.com/user-attachments/assets/b52c1d83-0997-4ebe-acd4-90ca47e61b9b)
![Screenshot 2024-09-23 at 2 00 42 PM](https://github.com/user-attachments/assets/dda0744b-5dd8-421c-9cf4-603cec504a96)
![Screenshot 2024-09-23 at 6 50 05 PM](https://github.com/user-attachments/assets/04d6da61-80e3-41d4-9769-5163e0e8c9ff)
![Screenshot 2024-09-23 at 6 50 12 PM](https://github.com/user-attachments/assets/c9cdefa9-f144-4a13-9513-d3c696b9c78d)
![Screenshot 2024-09-23 at 6 51 08 PM](https://github.com/user-attachments/assets/d89602e9-a5d5-4708-be64-d0a0bbe6ce33)
![Screenshot 2024-09-23 at 7 24 31 PM](https://github.com/user-attachments/assets/35b4a926-7d7c-404b-b5d4-071fce44b6d8)




 