### PR TITLE
feat: public holidays seeded data

### DIFF
--- a/src/data/prisma/seed/seed.ts
+++ b/src/data/prisma/seed/seed.ts
@@ -225,6 +225,27 @@ class Seeder {
       logger.info('Working Days table already contains data.');
     }
 
+    // Public Holidays
+    const publicHolidaysCount = await this.prisma.publicHolidays.count();
+    if (publicHolidaysCount === 0) {
+      const days = [
+        { name: 'New Year', date: '01/01/2025' },
+        { name: 'Easter', date: '20/04/2025' },
+        { name: 'Labor Day', date: '01/09/2025' },
+        { name: 'Christmas Day', date: '25/12/2025' },
+      ];
+      for (const day of days) {
+        await this.prisma.publicHolidays.create({
+          data: {
+            name: day.name,
+            date: day.date
+          },
+        });
+      }
+    } else {
+      logger.info('Working Days table already contains data.');
+    }
+
     logger.info('Data has been seeded successfully.');
   }
 }


### PR DESCRIPTION
## Tasks
- [x] Added seeded data for public holidays table 
- [x] The data can only be seeded if the `npx prisma db seed` script was ran while the table was empty
- [x] Screenshot/s
![Screenshot 2024-10-12 at 11 26 48 PM](https://github.com/user-attachments/assets/6d21c74b-6a18-4ba4-88ca-18478e9fe53b)
  