### PR TITLE
feat: get previous holidays 

### DIFF
--- a/src/data/prisma/migrations/20241122150037_update_holidays/migration.sql
+++ b/src/data/prisma/migrations/20241122150037_update_holidays/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Changed the type of `date` on the `PublicHolidays` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "PublicHolidays" DROP COLUMN "date",
+ADD COLUMN     "date" TIMESTAMP(3) NOT NULL;

--- a/src/data/prisma/schema.prisma
+++ b/src/data/prisma/schema.prisma
@@ -185,7 +185,7 @@ model Notifications {
 model PublicHolidays {
   id   String    @id @default(uuid())
   name String
-  date String
+  date DateTime
 }
 
 // Archieve tables

--- a/src/data/prisma/seed/seed.ts
+++ b/src/data/prisma/seed/seed.ts
@@ -229,10 +229,18 @@ class Seeder {
     const publicHolidaysCount = await this.prisma.publicHolidays.count();
     if (publicHolidaysCount === 0) {
       const days = [
-        { name: 'New Year', date: '01/01/2025' },
-        { name: 'Easter', date: '20/04/2025' },
-        { name: 'Labor Day', date: '01/09/2025' },
-        { name: 'Christmas Day', date: '25/12/2025' },
+        { name: 'New Year', date: new Date(2023, 0, 1) },
+        { name: 'Easter', date: new Date(2023, 3, 20) },
+        { name: 'Labor Day', date: new Date(2023, 8, 1) },
+        { name: 'Christmas Day', date: new Date(2023, 11, 25) },
+        { name: 'New Year', date: new Date(2024, 0, 1) },
+        { name: 'Easter', date: new Date(2024, 3, 20) },
+        { name: 'Labor Day', date: new Date(2024, 8, 1) },
+        { name: 'Christmas Day', date: new Date(2024, 11, 25) },
+        { name: 'New Year', date: new Date(2025, 0, 1) },
+        { name: 'Easter', date: new Date(2025, 3, 20) },
+        { name: 'Labor Day', date: new Date(2025, 8, 1) },
+        { name: 'Christmas Day', date: new Date(2025, 11, 25) },
       ];
       for (const day of days) {
         await this.prisma.publicHolidays.create({

--- a/src/features/Holidays/__tests__/mocks/index.ts
+++ b/src/features/Holidays/__tests__/mocks/index.ts
@@ -2,35 +2,53 @@ import { AddHolidayDto, UpdateHolidayDto, HolidayEntity } from '../../domain';
 
 export const addHolidayDtoMock: AddHolidayDto = {
   name: 'New Year',
-  date: '01/01/2025',
+  date: new Date(2025, 0, 1),
 };
 
 export const holidaysMock: HolidayEntity[] = [
   {
     id: '1',
     name: 'New Year',
-    date: '01/01/2025',
+    date: new Date(2025, 0, 1),
   },
   {
     id: '2',
     name: 'Easter',
-    date: '20/04/2025',
+    date: new Date(2025, 3, 20),
   },
   {
     id: '3',
     name: 'Labor Day',
-    date: '01/09/2025',
+    date: new Date(2025, 8, 1),
+  },
+];
+
+export const previousHolidaysMock: HolidayEntity[] = [
+  {
+    id: '1',
+    name: 'New Year',
+    date: new Date(2024, 0, 1),
+  },
+  {
+    id: '2',
+    name: 'Easter',
+    date: new Date(2024, 3, 20),
+  },
+  {
+    id: '3',
+    name: 'Labor Day',
+    date: new Date(2024, 8, 1),
   },
 ];
 
 export const updateHolidayDtoMock: UpdateHolidayDto = {
   id: '1',
   name: 'New Year',
-  date: '01/01/2025',
+  date: new Date(2025, 0, 1),
 };
 
 export const updatedHolidayMock: UpdateHolidayDto = {
   id: '1',
   name: 'Labor Day',
-  date: '01/02/2025',
+  date: new Date(2025, 1, 1),
 };

--- a/src/features/Holidays/__tests__/unit-tests/get-previous-holidays.test.ts
+++ b/src/features/Holidays/__tests__/unit-tests/get-previous-holidays.test.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '@prisma/client';
+import { vi, it, describe, beforeEach, expect } from 'vitest';
+import { prismaMock } from '../../../../__tests__/__mocks__';
+import { HolidaysDatasourceImpl } from '../../infrastructure';
+import { previousHolidaysMock } from '../mocks';
+
+describe('Returns all previous public holidays', () => {
+  let holidaysDatasource: HolidaysDatasourceImpl;
+
+  beforeEach(() => {
+    holidaysDatasource = new HolidaysDatasourceImpl(prismaMock as unknown as PrismaClient);
+    vi.clearAllMocks();
+  });
+
+  it('should return all previous holidays', async () => {
+    prismaMock.publicHolidays.findMany?.mockResolvedValueOnce(previousHolidaysMock);
+    const result = await holidaysDatasource.getPrevious({ page: 1, limit: 5 });
+    expect(typeof result).toBe('object');
+    expect(result.length).toEqual(previousHolidaysMock.length);
+  });
+});

--- a/src/features/Holidays/domain/datasources/holidays.datasource.ts
+++ b/src/features/Holidays/domain/datasources/holidays.datasource.ts
@@ -1,8 +1,9 @@
-import { AddHolidayDto, GetHolidaysDto, UpdateHolidayDto } from '../dtos';
+import { AddHolidayDto, GetHolidaysDto, GetPreviousHolidaysDto, UpdateHolidayDto } from '../dtos';
 import { HolidayEntity } from '../entities';
 
 export abstract class HolidaysDatasource {
   abstract add(holidaysDto: AddHolidayDto): Promise<HolidayEntity | null>;
   abstract get(holidaysDto: GetHolidaysDto): Promise<HolidayEntity[]>;
+  abstract getPrevious(holidaysDto: GetPreviousHolidaysDto): Promise<HolidayEntity[]>;
   abstract update(holidaysDto: UpdateHolidayDto): Promise<HolidayEntity | null>;
 }

--- a/src/features/Holidays/domain/dtos/add-holiday.dto.ts
+++ b/src/features/Holidays/domain/dtos/add-holiday.dto.ts
@@ -3,20 +3,20 @@ import { HolidaysInputValidation } from '../../infrastructure/validation/holiday
 export class AddHolidayDto {
   private constructor(
     public readonly name: string,
-    public readonly date: string,
+    public readonly date: Date,
   ) {}
 
   static add(object: { [key: string]: string }): [string?, AddHolidayDto?] {
     const { name, date } = object;
     const [day, month, year] = date.split('/').map(Number);
     const stringToDate = new Date(year, month - 1, day);
-    const dto = new AddHolidayDto(name, date);
-    const error = new HolidaysInputValidation().add(dto);
-    if (error) return [error, undefined];
     const currentDate = new Date();
-    if (stringToDate < currentDate) {
+    if (stringToDate.toString() === 'Invalid Date' || stringToDate < currentDate) {
       return ['Date can not be in the past', undefined];
     }
+    const dto = new AddHolidayDto(name, stringToDate);
+    const error = new HolidaysInputValidation().add(dto);
+    if (error) return [error, undefined];
     return [undefined, dto];
   }
 }

--- a/src/features/Holidays/domain/dtos/get-previous-holidays.dto.ts
+++ b/src/features/Holidays/domain/dtos/get-previous-holidays.dto.ts
@@ -1,0 +1,18 @@
+import { ParsedQs } from 'qs';
+import { HolidaysInputValidation } from '../../infrastructure/validation/holidays.validations.impl';
+
+export class GetPreviousHolidaysDto {
+  private constructor(
+    public readonly page?: number,
+    public readonly limit?: number,
+  ) {}
+
+  static getPrevious(object: ParsedQs): [string?, GetPreviousHolidaysDto?] {
+    const page = parseInt(object.page as string) || 1;
+    const limit = parseInt(object.limit as string) || 15;
+    const dto = new GetPreviousHolidaysDto(page, limit);
+    const error = new HolidaysInputValidation().getPrevious(dto);
+    if (error) return [error, undefined];
+    return [undefined, dto];
+  }
+}

--- a/src/features/Holidays/domain/dtos/index.ts
+++ b/src/features/Holidays/domain/dtos/index.ts
@@ -1,3 +1,4 @@
 export * from './add-holiday.dto';
 export * from './get-holidays.dto';
 export * from './update-holiday.dto';
+export * from './get-previous-holidays.dto';

--- a/src/features/Holidays/domain/dtos/update-holiday.dto.ts
+++ b/src/features/Holidays/domain/dtos/update-holiday.dto.ts
@@ -4,7 +4,7 @@ export class UpdateHolidayDto {
   private constructor(
     public readonly id: string,
     public readonly name: string,
-    public readonly date: string,
+    public readonly date: Date,
   ) {}
 
   static update(id: string, object: { [key: string]: string }): [string?, UpdateHolidayDto?] {
@@ -12,13 +12,13 @@ export class UpdateHolidayDto {
     if (!name && !date) return ['Provide a valid name and date', undefined];
     const [day, month, year] = date.split('/').map(Number);
     const stringToDate = new Date(year, month - 1, day);
-    const dto = new UpdateHolidayDto(id, name, date);
-    const error = new HolidaysInputValidation().update(dto);
-    if (error) return [error, undefined];
     const currentDate = new Date();
-    if (stringToDate < currentDate) {
+    if (stringToDate.toString() === 'Invalid Date' || stringToDate < currentDate) {
       return ['Date can not be in the past', undefined];
     }
+    const dto = new UpdateHolidayDto(id, name, stringToDate);
+    const error = new HolidaysInputValidation().update(dto);
+    if (error) return [error, undefined];
     return [undefined, dto];
   }
 }

--- a/src/features/Holidays/domain/entities/holiday.entity.ts
+++ b/src/features/Holidays/domain/entities/holiday.entity.ts
@@ -2,6 +2,6 @@ export class HolidayEntity {
   constructor(
     public id: string,
     public name: string,
-    public date: string,
+    public date: Date,
   ) {}
 }

--- a/src/features/Holidays/domain/interfaces/index.ts
+++ b/src/features/Holidays/domain/interfaces/index.ts
@@ -1,4 +1,4 @@
-import { AddHolidayDto, GetHolidaysDto, UpdateHolidayDto } from '../dtos';
+import { AddHolidayDto, GetHolidaysDto, GetPreviousHolidaysDto, UpdateHolidayDto } from '../dtos';
 import { HolidayEntity } from '../entities';
 
 // types
@@ -21,6 +21,10 @@ export interface AddHolidayUseCase {
 
 export interface GetAllHolidaysUseCase {
   execute(holidaysDto: GetHolidaysDto): Promise<allHolidaysResponse>;
+}
+
+export interface GetPreviousHolidaysUseCase {
+  execute(holidaysDto: GetPreviousHolidaysDto): Promise<allHolidaysResponse>;
 }
 
 export interface UpdateHolidayUseCase {

--- a/src/features/Holidays/domain/repositories/holidays.repository.ts
+++ b/src/features/Holidays/domain/repositories/holidays.repository.ts
@@ -1,8 +1,9 @@
-import { AddHolidayDto, GetHolidaysDto, UpdateHolidayDto } from '../dtos';
+import { AddHolidayDto, GetHolidaysDto, GetPreviousHolidaysDto, UpdateHolidayDto } from '../dtos';
 import { HolidayEntity } from '../entities';
 
 export abstract class HolidaysRepository {
   abstract add(holidaysDto: AddHolidayDto): Promise<HolidayEntity | null>;
   abstract get(holidaysDto: GetHolidaysDto): Promise<HolidayEntity[]>;
+  abstract getPrevious(holidaysDto: GetPreviousHolidaysDto): Promise<HolidayEntity[]>;
   abstract update(holidaysDto: UpdateHolidayDto): Promise<HolidayEntity | null>;
 }

--- a/src/features/Holidays/domain/use-cases/get-previous-holidays.use-case.ts
+++ b/src/features/Holidays/domain/use-cases/get-previous-holidays.use-case.ts
@@ -1,0 +1,15 @@
+import { GetPreviousHolidaysDto } from '../dtos';
+import { HolidaysRepository } from '../repositories';
+import { allHolidaysResponse, GetPreviousHolidaysUseCase } from '../interfaces';
+
+export class GetPreviousHolidays implements GetPreviousHolidaysUseCase {
+  constructor(private readonly repo: HolidaysRepository) {}
+  async execute(holidaysDto: GetPreviousHolidaysDto): Promise<allHolidaysResponse> {
+    const previousHolidays = await this.repo.getPrevious(holidaysDto);
+    return {
+      status: 'success',
+      message: 'previous holidays successfully fetched',
+      data: previousHolidays,
+    };
+  }
+}

--- a/src/features/Holidays/domain/use-cases/index.ts
+++ b/src/features/Holidays/domain/use-cases/index.ts
@@ -1,3 +1,4 @@
 export * from './add-holiday.use-case';
 export * from './get-all-holidays.use-case';
 export * from './update-holiday.use-case';
+export * from './get-previous-holidays.use-case';

--- a/src/features/Holidays/infrastructure/datasources/holidays.datasource.impl.ts
+++ b/src/features/Holidays/infrastructure/datasources/holidays.datasource.impl.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import {
   AddHolidayDto,
   GetHolidaysDto,
+  GetPreviousHolidaysDto,
   HolidayEntity,
   HolidaysDatasource,
   UpdateHolidayDto,
@@ -23,7 +24,7 @@ export class HolidaysDatasourceImpl implements HolidaysDatasource {
       const holiday = await this._prisma.publicHolidays.create({
         data: {
           name,
-          date: date,
+          date,
         },
       });
       return HolidayMapper.holidayEntityFromObject(holiday);
@@ -38,11 +39,50 @@ export class HolidaysDatasourceImpl implements HolidaysDatasource {
     const { page, limit } = holidaysDto;
     try {
       const offset = (page! - 1) * limit!;
+      const now = new Date();
       const holidays = await this._prisma.publicHolidays.findMany({
         select: {
           id: true,
           name: true,
           date: true,
+        },
+        orderBy: {
+          date: 'asc'
+        },
+        where: {
+          date: {
+            gte: now
+          }
+        },
+        skip: offset,
+        take: limit,
+      });
+      return holidays;
+    } catch (error) {
+      logger.error(error);
+      if (error instanceof CustomError) throw error;
+      throw CustomError.internalServerError();
+    }
+  }
+
+  async getPrevious(holidaysDto: GetPreviousHolidaysDto): Promise<HolidayEntity[]> {
+    const { page, limit } = holidaysDto;
+    try {
+      const offset = (page! - 1) * limit!;
+      const now = new Date();
+      const holidays = await this._prisma.publicHolidays.findMany({
+        select: {
+          id: true,
+          name: true,
+          date: true,
+        },
+        orderBy: {
+          date: 'desc'
+        },
+        where: {
+          date: {
+            lt: now,
+          },
         },
         skip: offset,
         take: limit,

--- a/src/features/Holidays/infrastructure/mapper/holiday.mapper.ts
+++ b/src/features/Holidays/infrastructure/mapper/holiday.mapper.ts
@@ -2,11 +2,7 @@ import { CustomError } from '../../../../domain';
 import { HolidayEntity } from '../../domain';
 
 export class HolidayMapper {
-  static holidayEntityFromObject(object: {
-    id: string;
-    name: string;
-    date: string;
-  }): HolidayEntity {
+  static holidayEntityFromObject(object: { id: string; name: string; date: Date }): HolidayEntity {
     const { id, name, date } = object;
 
     if (!name) throw CustomError.badRequest('Missing name');

--- a/src/features/Holidays/infrastructure/repositories/holidays.repository.impl.ts
+++ b/src/features/Holidays/infrastructure/repositories/holidays.repository.impl.ts
@@ -1,6 +1,7 @@
 import {
   AddHolidayDto,
   GetHolidaysDto,
+  GetPreviousHolidaysDto,
   HolidayEntity,
   HolidaysDatasource,
   HolidaysRepository,
@@ -18,6 +19,10 @@ export class HolidaysRepositoryIml extends HolidaysRepository {
 
   get(holidaysDto: GetHolidaysDto): Promise<HolidayEntity[]> {
     return this.datasource.get(holidaysDto);
+  }
+
+  getPrevious(holidaysDto: GetPreviousHolidaysDto): Promise<HolidayEntity[]> {
+    return this.datasource.getPrevious(holidaysDto);
   }
 
   update(holidaysDto: UpdateHolidayDto): Promise<HolidayEntity | null> {

--- a/src/features/Holidays/infrastructure/validation/holidays.validations.impl.ts
+++ b/src/features/Holidays/infrastructure/validation/holidays.validations.impl.ts
@@ -1,5 +1,15 @@
-import { AddHolidayDto, GetHolidaysDto, UpdateHolidayDto } from '../../domain';
-import { addHolidaySchema, getAllHolidaysSchema, updateHolidaySchema } from './joi-schemas';
+import {
+  AddHolidayDto,
+  GetHolidaysDto,
+  GetPreviousHolidaysDto,
+  UpdateHolidayDto,
+} from '../../domain';
+import {
+  addHolidaySchema,
+  getAllHolidaysSchema,
+  getPreviousHolidaysSchema,
+  updateHolidaySchema,
+} from './joi-schemas';
 
 export class HolidaysInputValidation {
   add(holidaysDto: AddHolidayDto): string | null {
@@ -10,6 +20,12 @@ export class HolidaysInputValidation {
 
   get(holidaysDto: GetHolidaysDto): string | null {
     const { error } = getAllHolidaysSchema.validate(holidaysDto);
+    if (error) return error.message;
+    return null;
+  }
+
+  getPrevious(holidaysDto: GetPreviousHolidaysDto): string | null {
+    const { error } = getPreviousHolidaysSchema.validate(holidaysDto);
     if (error) return error.message;
     return null;
   }

--- a/src/features/Holidays/infrastructure/validation/joi-schemas/add-holiday.schema.ts
+++ b/src/features/Holidays/infrastructure/validation/joi-schemas/add-holiday.schema.ts
@@ -7,13 +7,8 @@ export const addHolidaySchema = joi.object({
     'string.min': 'A holiday name must be more of 3 characters',
     'string.max': 'A holiday name must be less than 26 characters',
   }),
-  date: joi
-    .string()
-    .required()
-    .pattern(new RegExp('^(0[1-9]|[12][0-9]|3[01])/(0[1-9]|1[0-2])/\\d{4}$'))
-    .messages({
-      'string.empty': 'A valid holiday date is required',
-      'string.required': 'A valid holiday date is required',
-      'string.pattern.base': 'A valid holiday date follows dd/mm/yyyy pattern',
-    }),
+  date: joi.date().required().messages({
+    'date.empty': 'A valid holiday date is required',
+    'date.required': 'A valid holiday date is required',
+  }),
 });

--- a/src/features/Holidays/infrastructure/validation/joi-schemas/get-previous-holidays.schema.ts
+++ b/src/features/Holidays/infrastructure/validation/joi-schemas/get-previous-holidays.schema.ts
@@ -1,0 +1,13 @@
+import joi from 'joi';
+
+export const getPreviousHolidaysSchema = joi.object({
+  page: joi.number().optional().messages({
+    'string.empty': 'A number for page is required.',
+    'string.page': 'A number is required.',
+  }),
+
+  limit: joi.number().optional().messages({
+    'string.empty': 'A number for page is required.',
+    'string.page': 'A number is required.',
+  }),
+});

--- a/src/features/Holidays/infrastructure/validation/joi-schemas/index.ts
+++ b/src/features/Holidays/infrastructure/validation/joi-schemas/index.ts
@@ -1,3 +1,4 @@
 export * from './add-holiday.schema';
 export * from './get-holidays.schema';
 export * from './update-holiday.schema';
+export * from './get-previous-holidays.schema';

--- a/src/features/Holidays/infrastructure/validation/joi-schemas/update-holiday.schema.ts
+++ b/src/features/Holidays/infrastructure/validation/joi-schemas/update-holiday.schema.ts
@@ -12,13 +12,8 @@ export const updateHolidaySchema = joi.object({
     'string.min': 'A holiday name must be more of 3 characters',
     'string.max': 'A holiday name must be less than 26 characters',
   }),
-  date: joi
-    .string()
-    .required()
-    .pattern(new RegExp('^(0[1-9]|[12][0-9]|3[01])/(0[1-9]|1[0-2])/\\d{4}$'))
-    .messages({
-      'string.empty': 'A valid holiday date is required',
-      'string.required': 'A valid holiday date is required',
-      'string.pattern.base': 'A valid holiday date follows dd/mm/yyyy pattern',
-    }),
+  date: joi.date().required().messages({
+    'date.empty': 'A valid holiday date is required',
+    'date.required': 'A valid holiday date is required',
+  }),
 });

--- a/src/features/Holidays/preseentation/controller.holidays.ts
+++ b/src/features/Holidays/preseentation/controller.holidays.ts
@@ -5,6 +5,8 @@ import {
   GetAllHolidays,
   AddHolidayDto,
   GetHolidaysDto,
+  GetPreviousHolidaysDto,
+  GetPreviousHolidays,
   UpdateHolidayDto,
   UpdateHoliday,
   HolidaysRepository,
@@ -28,6 +30,15 @@ export class HolidaysController extends BaseController {
     const [error, dto] = GetHolidaysDto.get(req.query);
     if (error) return res.status(400).send({ error });
     new GetAllHolidays(this.repo)
+      .execute(dto!)
+      .then((data) => res.json(data))
+      .catch((error) => this.handleError(error, res));
+  };
+
+  getPrevious = (req: Request, res: Response) => {
+    const [error, dto] = GetPreviousHolidaysDto.getPrevious(req.query);
+    if (error) return res.status(400).send({ error });
+    new GetPreviousHolidays(this.repo)
       .execute(dto!)
       .then((data) => res.json(data))
       .catch((error) => this.handleError(error, res));

--- a/src/features/Holidays/preseentation/routes.holidays.ts
+++ b/src/features/Holidays/preseentation/routes.holidays.ts
@@ -12,6 +12,7 @@ export class HolidaysRoutes {
 
     router.post('/', [AuthMiddleware.authenticated, AuthMiddleware.authorized], controller.add);
     router.get('/', [AuthMiddleware.authenticated], controller.get);
+    router.get('/previous', [AuthMiddleware.authenticated], controller.getPrevious);
     router.patch(
       '/:id',
       [AuthMiddleware.authenticated, AuthMiddleware.authorized],


### PR DESCRIPTION
## Description 
Added GET /holidays/previous endpoint and changed the date data type in the Holidays entity and database table.

## Tasks done
- [x] Create an endpoint to get all previous holidays.
- [x] Only authenticated users can reach the endpoint.
- [x] Added unit tests for the endpoint.
- [x] Changed the data type of date from string to Date/DateTime in both the Holidays entity and PublicHolidays database table.
- [x] Updated GET /holidays to return the holidays in ascendingly.
- [x] Screenshot/s
![Screenshot 2024-11-22 at 6 51 43 PM](https://github.com/user-attachments/assets/71d3d856-3d44-44e4-9fa3-40e6a3cd90f0)
![Screenshot 2024-11-22 at 6 44 33 PM](https://github.com/user-attachments/assets/5a95508c-4eb3-4328-8e6e-6855985f43c6)
   
Updated GET /holidays to show the dates ascendingly
![Screenshot 2024-11-22 at 6 48 15 PM](https://github.com/user-attachments/assets/f01a1e36-4ba1-4d57-98f6-69b1ba5776ec)
